### PR TITLE
Address deprecation warning for accessing DOM nodes.

### DIFF
--- a/lib/spinner.jsx
+++ b/lib/spinner.jsx
@@ -23,7 +23,7 @@ SpinnerView = React.createClass({
 	componentDidMount() {
 		let options = _.extend({}, Meteor.Spinner.options, this.props.options);
 		this.spinner = new Spinner(options);
-		this.spinner.spin(this.refs.spinner.getDOMNode());	
+		this.spinner.spin(ReactDOM.findDOMNode(this.refs.spinner));	
 	},
 
 	componentWillUnmount() {
@@ -43,9 +43,9 @@ SpinnerMixin = {
       let allSubsReady = _.every(this.data.subscriptions, (subscription) => {
         return subscription.ready();
       });
-      
+
       let spinnerComponent;
-      if(this.spinnerWrapper) 
+      if(this.spinnerWrapper)
         spinnerComponent = this.spinnerWrapper(<SpinnerView />) ;
       else
         spinnerComponent = <SpinnerView />;


### PR DESCRIPTION
Addresses https://github.com/dpraburaj/meteor-react-spin/issues/1 for the deprecation warning.

```
Warning: ReactDOMComponent: Do not access .getDOMNode() of a DOM node; instead, use the node directly.
```

Let me know if anything else is needed.
